### PR TITLE
AIP-008 : Aion Interface Registry

### DIFF
--- a/AIP-004/AIP#004.md
+++ b/AIP-004/AIP#004.md
@@ -349,8 +349,8 @@ When an *operator* sends an `amount` of tokens from a *token holder* to a *recip
 - The balance of the *token holder* MUST be greater or equal to the `amount`&mdash;such that its resulting balance is greater or equal to zero (`0`) after the send.
 - The token contract MUST emit a `Sent` event with the correct values as defined in the [`Sent` Event][sent].
 - The *operator* MAY communicate any information in the `operatorData`.
-- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `ATSTokenSender` implementation via [ERC820].
-- The token contract MUST call the `tokensReceived` hook of the *recipient* if the *recipient* registers an `ATSTokenRecipient` implementation via [ERC820].
+- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `AIP004TokenSender` implementation via [AIP008].
+- The token contract MUST call the `tokensReceived` hook of the *recipient* if the *recipient* registers an `AIP004TokenRecipient` implementation via [AIP008].
 - The `data` and `operatorData` MUST be immutable during the entire send process&mdash;hence the same `data` and `operatorData` MUST be used to call both hooks and emit the `Sent` event.
 
 The token contract MUST `revert` when sending in any of the following cases:
@@ -453,13 +453,13 @@ Nonetheless, the rules below MUST be respected when minting for a *recipient*:
 - The balance of `0x0` MUST NOT be decreased.
 - The balance of the *recipient* MUST be increased by the amount of tokens minted.
 - The token contract MUST emit a `Minted` event with the correct values as defined in the [`Minted` Event][minted].
-- The token contract MUST call the `tokensReceived` hook of the *recipient* if the *recipient* registers an `ATSTokenRecipient` implementation via [ERC820].
+- The token contract MUST call the `tokensReceived` hook of the *recipient* if the *recipient* registers an `AIP004TokenRecipient` implementation via [AIP008].
 - The `data` and `operatorData` MUST be immutable during the entire mint process&mdash;hence the same `data` and `operatorData` MUST be used to call the `tokensReceived` hook and emit the `Minted` event.
 
 The token contract MUST `revert` when minting in any of the following cases:
 
 - The resulting *recipient* balance after the mint is not a multiple of the *granularity* defined by the token contract.
-- The *recipient* is a contract, and it does not implement the `ATSTokenRecipient` interface via [ERC820].
+- The *recipient* is a contract, and it does not implement the `AIP004TokenRecipient` interface via [AIP008].
 - The address of the *recipient* is `0x0`.
 
 *NOTE*: The initial token supply at the creation of the token contract MUST be considered as minting for the amount of the initial supply to the address (or addresses) receiving the initial supply.
@@ -505,7 +505,7 @@ The rules below MUST be respected when burning the tokens of a *token holder*:
 - The balance of `0x0` MUST NOT be increased.
 - The balance of the *token holder* MUST be decreased by amount of tokens burned.
 - The token contract MUST emit a `Burned` event with the correct values as defined in the [`Burned` Event][burned].
-- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `ATSTokenSender` implementation via [ERC820].
+- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `AIP004TokenSender` implementation via [AIP008].
 - The `operatorData` MUST be immutable during the entire burn process&mdash;hence the same `operatorData` MUST be used to call the `tokensToSend` hook and emit the `Burned` event.
 - The `data` field of the `tokensToSend` hook MUST be empty.
 
@@ -578,12 +578,12 @@ function operatorBurn(address from, uint128 amount, bytes operatorData) public;
 
 *NOTE*: `from` and `msg.sender` MAY be the same address. I.e., an address MAY call `operatorBurn` for itself. This call MUST be equivalent to `burn` with the addition that the *operator* MAY specify an explicit value for `operatorData` (which cannot be done with the `burn` function).
 
-#### **`ATSTokenSender` And The `tokensToSend` Hook**
+#### **`AIP004TokenSender` And The `tokensToSend` Hook**
 
-The `tokensToSend` hook notifies of any decrement of balance (send and burn) for a given *token holder*. Any address (regular or contract) wishing to be notified of token debits from their address MAY register the address of a contract implementing the `ATSTokenSender` interface described below via [ERC820].
+The `tokensToSend` hook notifies of any decrement of balance (send and burn) for a given *token holder*. Any address (regular or contract) wishing to be notified of token debits from their address MAY register the address of a contract implementing the `AIP004TokenSender` interface described below via [AIP008].
 
 ``` solidity
-interface ATSTokenSender {
+interface AIP004TokenSender {
     function tokensToSend(
         address operator,
         address from,
@@ -629,16 +629,16 @@ The following rules apply when calling the `tokensToSend` hook:
 - `operatorData` MUST contain the extra information provided by the address which triggered the decrease of the balance (if any).
 - The *token holder* MAY block a decrease of its balance by `revert`ing. (I.e., reject the withdrawal of tokens from its account.)
 
-*NOTE*: Multiple *token holders* MAY use the same implementation of `ATSTokenSender`.
+*NOTE*: Multiple *token holders* MAY use the same implementation of `AIP004TokenSender`.
 
-*NOTE*: An address can register at most one implementation at any given time for all tokens. Hence the `ATSTokenSender` MUST expect to be called by different token contracts. The `msg.sender` of the `tokensToSend` call is expected to be the address of the token contract.
+*NOTE*: An address can register at most one implementation at any given time for all tokens. Hence the `AIP004TokenSender` MUST expect to be called by different token contracts. The `msg.sender` of the `tokensToSend` call is expected to be the address of the token contract.
 
-#### **`ATSTokenRecipient` And The `tokensReceived` Hook**
+#### **`AIP004TokenRecipient` And The `tokensReceived` Hook**
 
-The `tokensReceived` hook notifies of any increment of the balance (send and mint) for a given *recipient*. Any address (regular or contract) wishing to be notified of token credits to their address MAY register the address of a contract implementing the `ATSTokenSender` interface described below via [ERC820].
+The `tokensReceived` hook notifies of any increment of the balance (send and mint) for a given *recipient*. Any address (regular or contract) wishing to be notified of token credits to their address MAY register the address of a contract implementing the `AIP004TokenSender` interface described below via [AIP008].
 
 ``` solidity
-interface ATSTokenRecipient {
+interface AIP004TokenRecipient {
     function tokensReceived(
         address operator,
         address from,
@@ -650,7 +650,7 @@ interface ATSTokenRecipient {
 }
 ```
 
-If the *recipient* is a contract, which has not registered an `ATSTokenRecipient` implementation; the token contract:
+If the *recipient* is a contract, which has not registered an `AIP004TokenRecipient` implementation; the token contract:
 
 - MUST `revert` if the `tokensReceived` hook is called from a mint or send call.
 - SHOULD accept if the `tokensReceived` hook is called from an ERC20 `transfer` or `transferFrom` call.
@@ -675,7 +675,7 @@ Notify a send or mint (if `from` is `0x0`) of `amount` tokens from the `from` ad
 function tokensReceived(address operator, address from, address to, uint128 amount, bytes data, bytes operatorData) public
 ```
 
-The following rules apply when calling the `tokensToSend` hook:
+The following rules apply when calling the `tokensReceived` hook:
 
 - The `tokensReceived` hook MUST be called every time the balance is incremented.
 - The `tokensReceived` hook MUST be called *after* the state is updated&mdash;i.e. *after* the balance is incremented.
@@ -688,15 +688,15 @@ The following rules apply when calling the `tokensToSend` hook:
 - `operatorData` MUST contain the extra information provided by the address which triggered the increase of the balance (if any).
 - The *token holder* MAY block an increase of its balance by `revert`ing. (I.e., reject the reception of tokens.)
 
-*NOTE*: Multiple *token holders* MAY use the same implementation of `ATSTokenRecipient`.
+*NOTE*: Multiple *token holders* MAY use the same implementation of `AIP004TokenRecipient`.
 
-*NOTE*: An address can register at most one implementation at any given time for all tokens. Hence the `ATSTokenRecipient` MUST expect to be called by different token contracts. The `msg.sender` of the `tokensReceived` call is expected to be the address of the token contract.
+*NOTE*: An address can register at most one implementation at any given time for all tokens. Hence the `AIP004TokenRecipient` MUST expect to be called by different token contracts. The `msg.sender` of the `tokensReceived` call is expected to be the address of the token contract.
 
 ### Solidity Interface
 
 ``` solidity
 /// @title ASC-ATS Aion Fungible Token Standard
-/// @dev See 
+/// @dev See
 
 pragma solidity 0.4.15;
 
@@ -753,7 +753,7 @@ This standard is based on [ERC-777](https://eips.ethereum.org/EIPS/eip-777) from
 
 ### Interface Registration
 
-[WIP: Define token registry]
+The token contract MUST register it's interface in the Aion Interface Registry as `sha3("AIP004Token")`. This is best accomplished using the constructor function if the interface is invariant. However, if the token interface compatibility with the standard changes over time, the token must also register these changes in the Aion Interface Registry.
 
 ### Cross Chain Functionality
 
@@ -790,9 +790,9 @@ N/A
 
 ## Dependencies
 
-The implementation of the Bridge Registry standard is a dependency to enable cross-chain movements. The Bridge Registry will be a new AIP. 
+The implementation of the Bridge Registry standard is a dependency to enable cross-chain movements. The Bridge Registry will be a new AIP.
 
-The implementation of the Bridge Contract standard is a dependency to enable cross-chain movements. The Bridge Operator will be a new AIP. 
+The implementation of the Bridge Contract standard is a dependency to enable cross-chain movements. The Bridge Operator will be a new AIP.
 
 The implementation of the Token Registry standard will be proposed as a new AIP.   
 

--- a/AIP-008/AIP#008.md
+++ b/AIP-008/AIP#008.md
@@ -1,0 +1,284 @@
+---
+Title: Aion Interface Registry
+Author(s): Sam Pajot-Phipps, Yao Sun, Stephane Gosselin
+Type: ASC (Aion Standards and Conventions)
+Status: DRAFT
+Creation Date: April 15th, 2018
+Contact Information: sam@aion.network
+---
+
+## Summary
+
+A standard for a universal registry smart contract where any address can register which interface it supports and delegate responsibility for its implementation. This standard follows the ERC-820 standard from Ethereum.
+
+## Value Proposition
+
+Provide a way to determine if a contract implements an interface of interest before executing a transaction.
+
+## Motivation
+
+Contract pseudo-introspection provides a standard way for the manager of a contract to describe the interface it has implemented such that it can be queried by other contracts before executing a transaction.
+
+Delegated implementation allows a manager to define a delegated address which implements an interface on behalf of the main address.
+
+The registry contract also provides a simple way of monitoring the deployment of contracts with an interface of interest.
+
+## Non-Goals
+
+## Success Metrics
+
+There are two key indicators of success for this standard:
+1) Number of interface registered
+2) Number of queries for interface registrations
+
+## Description
+
+A standard for a universal registry smart contract where any address can register which interface it supports and delegate responsibility for its implementation. This standard follows the ERC-820 standard from Ethereum.
+
+Contract pseudo-introspection provides a standard way for the manager of a contract to describe the interface it has implemented such that it can be queried by other contracts before executing a transaction.
+
+Delegated implementation allows a manager to define a delegated address which implements an interface on behalf of the main address.
+
+The registry contract also provides a simple way of monitoring the deployment of contracts with an interface of interest.
+
+## Specification
+
+### Definitions
+
+- Interface: The string name which represents the set of standard function signatures supported by the Target.
+- Target: The address which is claiming to support a given Interface.
+- Delegate: The address which is implementing the interface on behalf of the Target.
+- Manager: The address which holds the rights to modify the registration of the Target.
+
+### Interface Naming Conventions
+
+Each interface name must be unique. Following the guidelines used in ERC-820, interfaces for approved AIPs must use the following conventions.
+
+MUST be named AIP###XXXXX where ### is the number of the AIP and XXXXX should be the name of the interface in CamelCase. The meaning of this interface SHOULD be defined in the specified AIP.
+
+Examples:
+
+`sha3("AIP4Token")`
+`sha3("AIP4TokensSender")`
+`sha3("AIP4TokensRecipient")`
+
+### Methods for AIRDelegateInterface
+
+**`isDelegateFor` function**  
+
+Called to get whether or not this delegate contract implements the interface `interfaceHash` for the address `target`.  
+
+*NOTE*: Although the function returns true or false, it is necessary to return `sha3("AIR_ACCEPT_MAGIC")` to avoid issues with calling fallback functions which return booleans.  
+*NOTE*: This interface is only required if the `delegate` is a different address than the `manager`.  
+
+> **parameters**
+> `target`: Address supporting an interface.  
+> `interfaceHash`: Sha3 hash of the interface name.  
+
+``` solidity
+function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32)
+```
+
+### Methods for AionInterfaceRegistry
+
+**`InterfaceDelegateSet` event**  
+
+Indicate that the address `target` supports the interface `interfaceHash` through the delegate address `delegate`.
+
+If the `target` implements the interface itself, `target` and `delegate` will be equivalent.
+
+This event can be monitored to determine the number of contracts on the network which support a given interface.
+
+> **parameters**  
+> `target`: Address supporting an interface.  
+> `interfaceHash`: Sha3 hash of the interface name.  
+> `delegate`: Address implementing the interface on behalf of `target`.  
+
+``` solidity
+event InterfaceDelegateSet(address indexed target, bytes32 indexed interfaceHash, address indexed delegate)
+```
+
+**`ManagerChanged` event**  
+
+Indicate that the address `newManager` now controls the interface registration of the address `target`.
+
+> **parameters**  
+> `target`: Address supporting an interface.  
+> `newManager`: Address controlling the registration on behalf of `target`.  
+
+``` solidity
+event ManagerChanged(address indexed target, address indexed newManager)
+```
+
+**`getInterfaceDelegate` function**  
+
+Called to get the address of the delegate implementing the `interfaceHash` on behalf of the `target`.
+
+*NOTE*: MUST return address `0x0` if the `target` does not support the interface.
+
+> **parameters**
+> `target`: Address supporting an interface.  
+> `interfaceHash`: Sha3 hash of the interface name.  
+
+``` solidity
+function getInterfaceDelegate(address target, bytes32 interfaceHash) external constant returns (address)
+```
+
+**`getManager` function**  
+
+Called to get the address of the manager which controls the registration of the `target`.  
+
+*NOTE*: MUST return address `target` if no manager have been set.
+
+> **parameters**
+> `target`: Address supporting an interface.  
+
+``` solidity
+function getManager(address target) public constant returns(address)
+```
+
+**`interfaceHash` function**  
+
+Called to get the sha3 hash of an interface given its name as a string `interfaceName`.  
+
+> **parameters**
+> `interfaceName`: String of the interface name.  
+
+``` solidity
+function interfaceHash(string interfaceName) public constant returns(bytes32)
+```
+
+**`setInterfaceDelegate` function**  
+
+Called to set the address of the `delegate` which implements the interface `interfaceHash` on behalf of the `target`.  
+
+*NOTE*: MUST remove an interface by calling with `delegate` set to address 0.  
+*NOTE*: MUST call with `delegate` set as address `target` if the target contract implements the interface itself (without a delegate).  
+
+> **parameters**
+> `target`: Address supporting an interface.  
+> `interfaceName`: String of the interface name.  
+> `delegate`: Address implementing the interface on behalf of `target`.  
+
+``` solidity
+function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public
+```
+
+**`setManager` function**  
+
+Called to set the address of the `manager` which controls the registration of the `target`.  
+
+> **parameters**
+> `target`: Address supporting an interface.  
+> `manager`: Address of the manager for `target`.  
+
+``` solidity
+function setManager(address target, address manager) public
+```
+
+### Solidity Contract
+
+``` solidity
+pragma solidity 0.4.15;
+
+/// @dev The interface a contract MUST implement if it is the delegate of some (other) interface for any address other than itself.
+interface AIRDelegateInterface {
+    /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `target` or not.
+    /// @param addr Address for which the contract will implement the interface
+    /// @param interfaceHash sha3 hash of the name of the interface
+    /// @return AIR_ACCEPT_MAGIC only if the contract implements `interfaceHash` for the address `target`.
+    function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32);
+}
+
+contract AionInterfaceRegistry {
+    /// @notice Magic value which is returned if a contract implements an interface on behalf of some other address.
+    bytes32 constant AIR_ACCEPT_MAGIC = sha3("AIR_ACCEPT_MAGIC");
+
+    mapping (address => mapping(bytes32 => address)) interfaces;
+    mapping (address => address) managers;
+
+    modifier canManage(address target) {
+        require(getManager(target) == msg.sender);
+        _;
+    }
+
+    /// @notice Indicates a contract is the `delegate` of `interfaceHash` for `target`.
+    event InterfaceDelegateSet(address indexed target, bytes32 indexed interfaceHash, address indexed delegate);
+    /// @notice Indicates `newManager` is the address of the new manager for `target`.
+    event ManagerChanged(address indexed target, address indexed newManager);
+
+    /// @notice Query if an address implements an interface and through which contract.
+    /// @param target Address being queried for the delegate of an interface.
+    /// @param interfaceHash sha3 hash of the name of the interface as a string.
+    /// @return The address of the contract which implements the interface `interfaceHash` for `target`
+    /// or `0x0` if `target` did not register a delegate for this interface.
+    function getInterfaceDelegate(address target, bytes32 interfaceHash) public constant returns (address) {
+        return interfaces[target][interfaceHash];
+    }
+
+    /// @notice Get the manager of an address.
+    /// @param target Address for which to return the manager.
+    /// @return Address of the manager for a given address.
+    function getManager(address target) public constant returns(address) {
+        // By default the manager of an address is the same address
+        if (managers[target] == address(0))
+            return target;
+        else
+            return managers[target];
+    }
+
+    /// @notice Compute the sha3 hash of an interface given its name.
+    /// @param interfaceName Name of the interface as a string.
+    /// @return The sha3 hash of an interface name.
+    function interfaceHash(string interfaceName) public constant returns(bytes32) {
+        return sha3(interfaceName);
+    }
+
+    /// @notice Sets the contract which implements a specific interface for an address.
+    /// Only the manager defined for that address can set it.
+    /// (Each address is the manager for itself until it sets a new manager.)
+    /// @param target Address to define the interface for.
+    /// @param interfaceHash sha3 hash of the name of the interface as a string.
+    function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public canManage(target) {
+        if (delegate != address(0) && delegate != msg.sender)
+            require(AIRDelegateInterface(delegate).isDelegateFor(target, interfaceHash) == AIR_ACCEPT_MAGIC);
+        interfaces[target][interfaceHash] = delegate;
+        InterfaceDelegateSet(target, interfaceHash, delegate);
+    }
+
+    /// @notice Sets the `manager` as manager for the `target` address.
+    /// The new manager will be able to call `setInterfaceDelegate` for `target`.
+    /// @param target Address for which to set the new manager.
+    /// @param manager Address of the new manager for `target`. (Pass `0x0` to reset the manager to `target` itself.)
+    function setManager(address target, address manager) public canManage(target) {
+        managers[target] = manager == target ? address(0) : manager;
+        ManagerChanged(target, manager);
+    }
+}
+```
+
+## Logic
+
+This standard is based on [ERC-820](https://eips.ethereum.org/EIPS/eip-820) from Ethereum. The following modifications have been made in migrating the standard.
+
+- Removed compatibility with ERC-165 to reduce complexity and save gas.
+
+## Risks & Assumptions
+
+This standard does not guarantee that a given contract will behave as described by the associated interface. Since interface registration is perform on an opt-in basis by the author of the smart contract, users querying the interface registry must assume the author could register a false interface.
+
+## Test Cases
+
+N/A
+
+## Implementations
+
+N/A
+
+## Dependencies
+
+N/A
+
+## Copyright
+
+All AIP’s are public domain. Copyright waiver: https://creativecommons.org/publicdomain/zero/1.0/

--- a/AIP-008/AIP#008.md
+++ b/AIP-008/AIP#008.md
@@ -184,9 +184,9 @@ pragma solidity 0.4.15;
 /// @dev The interface a contract MUST implement if it is the delegate of some (other) interface for any address other than itself.
 interface AIRDelegateInterface {
     /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `target` or not.
-    /// @param addr Address for which the contract will implement the interface
+    /// @param target Address for which the contract will implement the interface
     /// @param interfaceHash sha3 hash of the name of the interface
-    /// @return AIR_ACCEPT_MAGIC only if the contract implements `interfaceHash` for the address `target`.
+    /// @return sha3("AIR_ACCEPT_MAGIC") only if the contract implements `interfaceHash` for the address `target`.
     function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32);
 }
 
@@ -211,7 +211,7 @@ contract AionInterfaceRegistry {
     /// @param target Address being queried for the delegate of an interface.
     /// @param interfaceHash sha3 hash of the name of the interface as a string.
     /// @return The address of the contract which implements the interface `interfaceHash` for `target`
-    /// or `0x0` if `target` did not register a delegate for this interface.
+    /// or `0x0` if `target` did not register this interface.
     function getInterfaceDelegate(address target, bytes32 interfaceHash) public constant returns (address) {
         return interfaces[target][interfaceHash];
     }
@@ -239,6 +239,7 @@ contract AionInterfaceRegistry {
     /// (Each address is the manager for itself until it sets a new manager.)
     /// @param target Address to define the interface for.
     /// @param interfaceHash sha3 hash of the name of the interface as a string.
+    /// @param delegate Address of the delegate which implements the interface `interfaceHash` for `target`.
     function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public canManage(target) {
         if (delegate != address(0) && delegate != msg.sender)
             require(AIRDelegateInterface(delegate).isDelegateFor(target, interfaceHash) == AIR_ACCEPT_MAGIC);

--- a/AIP-008/AIP#008.md
+++ b/AIP-008/AIP#008.md
@@ -58,9 +58,9 @@ MUST be named AIP###XXXXX where ### is the number of the AIP and XXXXX should be
 
 Examples:
 
-`sha3("AIP4Token")`
-`sha3("AIP4TokensSender")`
-`sha3("AIP4TokensRecipient")`
+`sha3("AIP004Token")`
+`sha3("AIP004TokensSender")`
+`sha3("AIP004TokensRecipient")`
 
 ### Methods for AIRDelegateInterface
 

--- a/AIP-008/AionInterfaceRegistry.sol
+++ b/AIP-008/AionInterfaceRegistry.sol
@@ -1,0 +1,77 @@
+pragma solidity 0.4.15;
+
+/// @dev The interface a contract MUST implement if it is the delegate of some (other) interface for any address other than itself.
+interface AIRDelegateInterface {
+    /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `target` or not.
+    /// @param addr Address for which the contract will implement the interface
+    /// @param interfaceHash sha3 hash of the name of the interface
+    /// @return sha3("AIR_ACCEPT_MAGIC") only if the contract implements `interfaceHash` for the address `target`.
+    function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32);
+}
+
+contract AionInterfaceRegistry {
+    /// @notice Magic value which is returned if a contract implements an interface on behalf of some other address.
+    bytes32 constant AIR_ACCEPT_MAGIC = sha3("AIR_ACCEPT_MAGIC");
+
+    mapping (address => mapping(bytes32 => address)) interfaces;
+    mapping (address => address) managers;
+
+    modifier canManage(address target) {
+        require(getManager(target) == msg.sender);
+        _;
+    }
+
+    /// @notice Indicates a contract is the `delegate` of `interfaceHash` for `target`.
+    event InterfaceDelegateSet(address indexed target, bytes32 indexed interfaceHash, address indexed delegate);
+    /// @notice Indicates `newManager` is the address of the new manager for `target`.
+    event ManagerChanged(address indexed target, address indexed newManager);
+
+    /// @notice Query if an address implements an interface and through which contract.
+    /// @param target Address being queried for the delegate of an interface.
+    /// @param interfaceHash sha3 hash of the name of the interface as a string.
+    /// @return The address of the contract which implements the interface `interfaceHash` for `target`
+    /// or `0x0` if `target` did not register this interface.
+    function getInterfaceDelegate(address target, bytes32 interfaceHash) public constant returns (address) {
+        return interfaces[target][interfaceHash];
+    }
+
+    /// @notice Get the manager of an address.
+    /// @param target Address for which to return the manager.
+    /// @return Address of the manager for a given address.
+    function getManager(address target) public constant returns(address) {
+        // By default the manager of an address is the same address
+        if (managers[target] == address(0))
+            return target;
+        else
+            return managers[target];
+    }
+
+    /// @notice Compute the sha3 hash of an interface given its name.
+    /// @param interfaceName Name of the interface as a string.
+    /// @return The sha3 hash of an interface name.
+    function interfaceHash(string interfaceName) public constant returns(bytes32) {
+        return sha3(interfaceName);
+    }
+
+    /// @notice Sets the contract which implements a specific interface for an address.
+    /// Only the manager defined for that address can set it.
+    /// (Each address is the manager for itself until it sets a new manager.)
+    /// @param target Address to define the interface for.
+    /// @param interfaceHash sha3 hash of the name of the interface as a string.
+    /// @param delegate Address of the delegate which implements the interface `interfaceHash` for `target`.
+    function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public canManage(target) {
+        if (delegate != address(0) && delegate != msg.sender)
+            require(AIRDelegateInterface(delegate).isDelegateFor(target, interfaceHash) == AIR_ACCEPT_MAGIC);
+        interfaces[target][interfaceHash] = delegate;
+        InterfaceDelegateSet(target, interfaceHash, delegate);
+    }
+
+    /// @notice Sets the `manager` as manager for the `target` address.
+    /// The new manager will be able to call `setInterfaceDelegate` for `target`.
+    /// @param target Address for which to set the new manager.
+    /// @param manager Address of the new manager for `target`. (Pass `0x0` to reset the manager to `target` itself.)
+    function setManager(address target, address manager) public canManage(target) {
+        managers[target] = manager == target ? address(0) : manager;
+        ManagerChanged(target, manager);
+    }
+}

--- a/AIP-008/AionInterfaceRegistry.sol
+++ b/AIP-008/AionInterfaceRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.15;
 /// @dev The interface a contract MUST implement if it is the delegate of some (other) interface for any address other than itself.
 interface AIRDelegateInterface {
     /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `target` or not.
-    /// @param addr Address for which the contract will implement the interface
+    /// @param target Address for which the contract will implement the interface
     /// @param interfaceHash sha3 hash of the name of the interface
     /// @return sha3("AIR_ACCEPT_MAGIC") only if the contract implements `interfaceHash` for the address `target`.
     function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32);


### PR DESCRIPTION
---
Title: Aion Interface Registry
Author(s): Sam Pajot-Phipps, Yao Sun, Stephane Gosselin
Type: ASC (Aion Standards and Conventions)
Status: Rejected
Creation Date: April 15th, 2018
Contact Information: sam@aion.network

---

## Summary

A standard for a universal registry smart contract where any address can register which interface it supports and delegate responsibility for its implementation. This standard follows the ERC-820 standard from Ethereum.

## Value Proposition

Provide a way to determine if a contract implements an interface of interest before executing a transaction.

## Motivation

Contract pseudo-introspection provides a standard way for the manager of a contract to describe the interface it has implemented such that it can be queried by other contracts before executing a transaction.

Delegated implementation allows a manager to define a delegated address which implements an interface on behalf of the main address.

The registry contract also provides a simple way of monitoring the deployment of contracts with an interface of interest.

## Non-Goals

## Success Metrics

There are two key indicators of success for this standard:
1) Number of interface registered
2) Number of queries for interface registrations

## Description

A standard for a universal registry smart contract where any address can register which interface it supports and delegate responsibility for its implementation. This standard follows the ERC-820 standard from Ethereum.

Contract pseudo-introspection provides a standard way for the manager of a contract to describe the interface it has implemented such that it can be queried by other contracts before executing a transaction.

Delegated implementation allows a manager to define a delegated address which implements an interface on behalf of the main address.

The registry contract also provides a simple way of monitoring the deployment of contracts with an interface of interest.

## Specification

### Definitions

- Interface: The string name which represents the set of standard function signatures supported by the Target.
- Target: The address which is claiming to support a given Interface.
- Delegate: The address which is implementing the interface on behalf of the Target.
- Manager: The address which holds the rights to modify the registration of the Target.

### Interface Naming Conventions

Each interface name must be unique. Following the guidelines used in ERC-820, interfaces for approved AIPs must use the following conventions.

MUST be named AIP###XXXXX where ### is the number of the AIP and XXXXX should be the name of the interface in CamelCase. The meaning of this interface SHOULD be defined in the specified AIP.

Examples:

`sha3("AIP004Token")`
`sha3("AIP004TokensSender")`
`sha3("AIP004TokensRecipient")`

### Methods for AIRDelegateInterface

**`isDelegateFor` function**  

Called to get whether or not this delegate contract implements the interface `interfaceHash` for the address `target`.  

*NOTE*: Although the function returns true or false, it is necessary to return `sha3("AIR_ACCEPT_MAGIC")` to avoid issues with calling fallback functions which return booleans.  
*NOTE*: This interface is only required if the `delegate` is a different address than the `manager`.  

> **parameters**
> `addr`: Address supporting an interface.  
> `interfaceHash`: Sha3 hash of the interface name.  

``` solidity
function isDelegateFor(address addr, bytes32 interfaceHash) external constant returns(bytes32);
```

### Methods for AionInterfaceRegistry

**`InterfaceDelegateSet` event**  

Indicate that the address `target` supports the interface `interfaceHash` through the delegate address `delegate`.

If the `target` implements the interface itself, `target` and `delegate` will be equivalent.

This event can be monitored to determine the number of contracts on the network which support a given interface.

> **parameters**  
> `target`: Address supporting an interface.  
> `interfaceHash`: Sha3 hash of the interface name.  
> `delegate`: Address implementing the interface on behalf of `target`.  

``` solidity
event InterfaceDelegateSet(address indexed target, bytes32 indexed interfaceHash, address indexed delegate)
```

**`ManagerChanged` event**  

Indicate that the address `newManager` now controls the interface registration of the address `target`.

> **parameters**  
> `target`: Address supporting an interface.  
> `newManager`: Address controlling the registration on behalf of `target`.  

``` solidity
event ManagerChanged(address indexed target, address indexed newManager)
```

**`getInterfaceDelegate` function**  

Called to get the address of the delegate implementing the `interfaceHash` on behalf of the `target`.

*NOTE*: MUST return address `0x0` if the `target` does not support the interface.

> **parameters**
> `target`: Address supporting an interface.  
> `interfaceHash`: Sha3 hash of the interface name.  

``` solidity
function getInterfaceDelegate(address target, bytes32 interfaceHash) external constant returns (address)
```

**`getManager` function**  

Called to get the address of the manager which controls the registration of the `target`.  

*NOTE*: MUST return address `target` if no manager have been set.

> **parameters**
> `target`: Address supporting an interface.  

``` solidity
function getManager(address target) public constant returns(address)
```

**`interfaceHash` function**  

Called to get the sha3 hash of an interface given its name as a string `interfaceName`.  

> **parameters**
> `interfaceName`: String of the interface name.  

``` solidity
function interfaceHash(string interfaceName) public constant returns(bytes32)
```

**`setInterfaceDelegate` function**  

Called to set the address of the `delegate` which implements the interface `interfaceHash` on behalf of the `target`.  

*NOTE*: MUST remove an interface by calling with `delegate` set to address 0.  
*NOTE*: MUST call with `delegate` set as address `target` if the target contract implements the interface itself (without a delegate).  

> **parameters**
> `target`: Address supporting an interface.  
> `interfaceName`: String of the interface name.  
> `delegate`: Address implementing the interface on behalf of `target`.  

``` solidity
function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public
```

**`setManager` function**  

Called to set the address of the `manager` which controls the registration of the `target`.  

> **parameters**
> `target`: Address supporting an interface.  
> `manager`: Address of the manager for `target`.  

``` solidity
function setManager(address target, address manager) public
```

### Solidity Contract

``` solidity
pragma solidity 0.4.15;

/// @dev The interface a contract MUST implement if it is the delegate of some (other) interface for any address other than itself.
interface AIRDelegateInterface {
    /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `target` or not.
    /// @param addr Address for which the contract will implement the interface
    /// @param interfaceHash sha3 hash of the name of the interface
    /// @return AIR_ACCEPT_MAGIC only if the contract implements `interfaceHash` for the address `target`.
    function isDelegateFor(address target, bytes32 interfaceHash) external constant returns(bytes32);
}

contract AionInterfaceRegistry {
    /// @notice Magic value which is returned if a contract implements an interface on behalf of some other address.
    bytes32 constant AIR_ACCEPT_MAGIC = sha3("AIR_ACCEPT_MAGIC");

    mapping (address => mapping(bytes32 => address)) interfaces;
    mapping (address => address) managers;

    modifier canManage(address target) {
        require(getManager(target) == msg.sender);
        _;
    }

    /// @notice Indicates a contract is the `delegate` of `interfaceHash` for `target`.
    event InterfaceDelegateSet(address indexed target, bytes32 indexed interfaceHash, address indexed delegate);
    /// @notice Indicates `newManager` is the address of the new manager for `target`.
    event ManagerChanged(address indexed target, address indexed newManager);

    /// @notice Query if an address implements an interface and through which contract.
    /// @param target Address being queried for the delegate of an interface.
    /// @param interfaceHash sha3 hash of the name of the interface as a string.
    /// @return The address of the contract which implements the interface `interfaceHash` for `target`
    /// or `0x0` if `target` did not register a delegate for this interface.
    function getInterfaceDelegate(address target, bytes32 interfaceHash) public constant returns (address) {
        return interfaces[target][interfaceHash];
    }

    /// @notice Get the manager of an address.
    /// @param target Address for which to return the manager.
    /// @return Address of the manager for a given address.
    function getManager(address target) public constant returns(address) {
        // By default the manager of an address is the same address
        if (managers[target] == address(0))
            return target;
        else
            return managers[target];
    }

    /// @notice Compute the sha3 hash of an interface given its name.
    /// @param interfaceName Name of the interface as a string.
    /// @return The sha3 hash of an interface name.
    function interfaceHash(string interfaceName) public constant returns(bytes32) {
        return sha3(interfaceName);
    }

    /// @notice Sets the contract which implements a specific interface for an address.
    /// Only the manager defined for that address can set it.
    /// (Each address is the manager for itself until it sets a new manager.)
    /// @param target Address to define the interface for.
    /// @param interfaceHash sha3 hash of the name of the interface as a string.
    function setInterfaceDelegate(address target, bytes32 interfaceHash, address delegate) public canManage(target) {
        if (delegate != address(0) && delegate != msg.sender)
            require(AIRDelegateInterface(delegate).isDelegateFor(target, interfaceHash) == AIR_ACCEPT_MAGIC);
        interfaces[target][interfaceHash] = delegate;
        InterfaceDelegateSet(target, interfaceHash, delegate);
    }

    /// @notice Sets the `manager` as manager for the `target` address.
    /// The new manager will be able to call `setInterfaceDelegate` for `target`.
    /// @param target Address for which to set the new manager.
    /// @param manager Address of the new manager for `target`. (Pass `0x0` to reset the manager to `target` itself.)
    function setManager(address target, address manager) public canManage(target) {
        managers[target] = manager == target ? address(0) : manager;
        ManagerChanged(target, manager);
    }
}
```

## Logic

This standard is based on [ERC-820](https://eips.ethereum.org/EIPS/eip-820) from Ethereum. The following modifications have been made in migrating the standard.

- Removed compatibility with ERC-165 to reduce complexity and save gas.

## Risks & Assumptions

This standard does not guarantee that a given contract will behave as described by the associated interface. Since interface registration is perform on an opt-in basis by the author of the smart contract, users querying the interface registry must assume the author could register a false interface.

## Test Cases

N/A

## Implementations

N/A

## Dependencies

N/A

## Copyright

All AIP’s are public domain. Copyright waiver: https://creativecommons.org/publicdomain/zero/1.0/
